### PR TITLE
clang format edit AlwaysBreakAfterDefinitionReturnType

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,4 +7,4 @@ AllowShortIfStatementsOnASingleLine: Never
 IndentCaseLabels: false
 ColumnLimit: 120
 AccessModifierOffset: -4
-AlwaysBreakAfterDefinitionReturnType: All
+AlwaysBreakAfterDefinitionReturnType: None

--- a/communicator/main.cpp
+++ b/communicator/main.cpp
@@ -2,8 +2,7 @@
 
 #include "mainwindow.h"
 
-int
-main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
     QApplication a(argc, argv);
     MainWindow w;
     w.show();


### PR DESCRIPTION
changed format from:
int
main()
to:
int main()